### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/client/convert.go
+++ b/pkg/client/convert.go
@@ -45,10 +45,7 @@ func convertV1User2Resource(user v1.User) (*v2.Resource, error) {
 		"generate_name": user.GenerateName,
 	}
 
-	traits := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
-		rs.WithCreatedAt(user.CreationTimestamp.Time),
-	}
+	traits := []rs.UserTraitOption{}
 
 	return rs.NewUserResource(
 		user.Name,
@@ -62,6 +59,8 @@ func convertV1User2Resource(user v1.User) (*v2.Resource, error) {
 		},
 		string(user.UID),
 		traits,
+		rs.WithResourceProfile(profile),
+		rs.WithResourceCreatedAt(user.CreationTimestamp.Time),
 	)
 }
 
@@ -90,7 +89,6 @@ func convertV1RoleList2Resource(roleList rbacv1.Role) (*v2.Resource, error) {
 	}
 
 	traits := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
 		// FIXME(shackra): add creation time
 	}
 
@@ -106,6 +104,7 @@ func convertV1RoleList2Resource(roleList rbacv1.Role) (*v2.Resource, error) {
 		},
 		string(roleList.UID),
 		traits,
+		rs.WithResourceProfile(profile),
 	)
 }
 
@@ -177,9 +176,7 @@ func convertV1Group2Resource(group v1.Group) (*v2.Resource, error) {
 		"created_at":    group.CreationTimestamp.Format(time.RFC3339),
 	}
 
-	traits := []rs.GroupTraitOption{
-		rs.WithGroupProfile(profile),
-	}
+	traits := []rs.GroupTraitOption{}
 
 	return rs.NewGroupResource(
 		group.GetName(),
@@ -192,5 +189,6 @@ func convertV1Group2Resource(group v1.Group) (*v2.Resource, error) {
 		},
 		string(group.UID),
 		traits,
+		rs.WithResourceProfile(profile),
 	)
 }


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
